### PR TITLE
Avoid error "decode Array as JSON"

### DIFF
--- a/polymer-color-picker.html
+++ b/polymer-color-picker.html
@@ -27,7 +27,7 @@ You can configure the color palette being used using the `colorList` array and
 the `columnCount` property, which specifies how many "generic" colours (i.e. columns
 in the picker) you want to display.
 
-    <polymer-color-picker column-count=5 color-list='["#65a5f2", "#83be54", "#f0d551", "#e5943c", "#a96ddb", ]'></polymer-color-picker>
+    <polymer-color-picker column-count=5 color-list='["#65a5f2", "#83be54", "#f0d551", "#e5943c", "#a96ddb"]'></polymer-color-picker>
 
 ### Styling
 


### PR DESCRIPTION
The list in the example in line #30 was with a _comma_ to more. That to me raised "Polymer::Attributes: couldn`t decode Array as JSON".
